### PR TITLE
Only update current-read-interaction when run as the main program

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -43,7 +43,9 @@
 
 (define-syntax-rule (ecma:module-begin form ...)
   (#%module-begin
-   (current-read-interaction eval-read-interaction)
+   (module #%configure-runtime racket/base
+     (require ecmascript/eval)
+     (current-read-interaction eval-read-interaction))
    form ...))
 
 (define-syntax-rule (ecma:top-interaction . form)


### PR DESCRIPTION
So that when a `#lang ecmascript` file is required into a file, it doesn't affect the reader of that file.
