### PR TITLE
Use runtime-config language-info to set up repl reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 compiled/
 doc/
+*~

--- a/lang/language-info.rkt
+++ b/lang/language-info.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(provide get-language-info)
+
+(define (get-language-info data)
+  (lambda (key default)
+    (case key
+      [(configure-runtime)
+       '(#[ecmascript/lang/runtime-config configure #f])]
+      [else default])))

--- a/lang/reader.rkt
+++ b/lang/reader.rkt
@@ -2,6 +2,7 @@
 ecmascript
 #:read ecma:read
 #:read-syntax ecma:read-syntax
+#:language-info #(ecmascript/lang/language-info get-language-info #f)
 #:whole-body-readers? #t
 
 (require "../init.rkt"

--- a/lang/runtime-config.rkt
+++ b/lang/runtime-config.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(provide configure)
+
+(require ecmascript/eval)
+
+(define (configure data)
+  (current-read-interaction eval-read-interaction))

--- a/main.rkt
+++ b/main.rkt
@@ -35,16 +35,11 @@
          new
 
          (rename-out
-          [ecma:module-begin #%module-begin]
           [ecma:top-interaction #%top-interaction])
 
+         #%module-begin
          #%app
          #%datum)
-
-(define-syntax-rule (ecma:module-begin form ...)
-  (#%module-begin
-   (current-read-interaction eval-read-interaction)
-   form ...))
 
 (define-syntax-rule (ecma:top-interaction . form)
   (get-value form))


### PR DESCRIPTION
So that when a `#lang ecmascript` file is required into a file, it
doesn't affect the reader of that file.
